### PR TITLE
Non-recursive Globus Sync

### DIFF
--- a/proxystore/store/globus.py
+++ b/proxystore/store/globus.py
@@ -493,7 +493,10 @@ class GlobusStore(RemoteStore):
                     ),
                 )
 
-        tdata = self._transfer_client.submit_transfer(transfer_task)
+        if delete:
+            tdata = self._transfer_client.submit_delete(transfer_task)
+        else:
+            tdata = self._transfer_client.submit_transfer(transfer_task)
 
         return tdata["task_id"]
 

--- a/proxystore/test/store/utils.py
+++ b/proxystore/test/store/utils.py
@@ -65,30 +65,6 @@ GLOBUS_STORE = {
 }
 
 
-class MockTransferClient:
-    """Mock the Globus TransferClient."""
-
-    def __init__(self, *args, **kwargs):
-        """Init MockTransferClient."""
-        pass
-
-    def get_task(self, *args, **kwargs):
-        """Get task."""
-        return None
-
-    def submit_delete(self, *args, **kwargs):
-        """Submit DeleteData."""
-        return {"task_id": str(uuid.uuid4())}
-
-    def submit_transfer(self, *args, **kwargs):
-        """Submit TransferData."""
-        return {"task_id": str(uuid.uuid4())}
-
-    def task_wait(self, *args, **kwargs):
-        """Wait on tasks."""
-        return True
-
-
 class MockTransferData:
     """Mock the Globus TransferData."""
 
@@ -104,8 +80,10 @@ class MockTransferData:
         """Index MockTransferData."""
         return self.__dict__[key]
 
-    def add_item(self, *args, **kwargs):
+    def add_item(self, source_path: str, destination_path: str, **kwargs):
         """Add item."""
+        assert isinstance(source_path, str)
+        assert isinstance(destination_path, str)
         return
 
 
@@ -124,9 +102,38 @@ class MockDeleteData:
         """Index MockDeleteData."""
         return self.__dict__[key]
 
-    def add_item(self, *args, **kwargs):
+    def add_item(self, path: str, **kwargs):
         """Add item."""
+        assert isinstance(path, str)
         return
+
+
+class MockTransferClient:
+    """Mock the Globus TransferClient."""
+
+    def __init__(self, *args, **kwargs):
+        """Init MockTransferClient."""
+        pass
+
+    def get_task(self, task_id: str):
+        """Get task."""
+        assert isinstance(task_id, str)
+        return None
+
+    def submit_delete(self, delete_data: MockDeleteData):
+        """Submit DeleteData."""
+        assert isinstance(delete_data, MockDeleteData)
+        return {"task_id": str(uuid.uuid4())}
+
+    def submit_transfer(self, transfer_data: MockTransferData):
+        """Submit TransferData."""
+        assert isinstance(transfer_data, MockTransferData)
+        return {"task_id": str(uuid.uuid4())}
+
+    def task_wait(self, task_id: str, **kwargs):
+        """Wait on tasks."""
+        assert isinstance(task_id, str)
+        return True
 
 
 class MockGlobusAuth:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Previously, get/set operations on the `GlobusStore` would trigger a recursive sync of the entire local directory used for storing serialized objects.
This has issues, however, when multiple Python processes are writing to the same local directory causing files to change in the middle of another process scanning the directory or validating a successful transfer. 
This commit changes `GlobusStore` to specify which files should be synced to avoid concurrency issues.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->


### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Ran unittests. Modified mocked Globus objects to validate that Globus transfer functions receive the correct datatypes from ProxyStore.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
