### PR TITLE
Make it easier to get stats given proxy

### DIFF
--- a/proxystore/store/base.py
+++ b/proxystore/store/base.py
@@ -51,6 +51,11 @@ class Store(metaclass=ABCMeta):
 
         logger.debug(f'Initialized {self}')
 
+    @property
+    def has_stats(self) -> bool:
+        """Whether the store keeps track of performance stats"""
+        return self._stats is not None
+
     def __repr__(self) -> str:
         """Represent Store instance as string."""
         s = f'{ps.utils.fullname(self.__class__)}('

--- a/tests/store/local_test.py
+++ b/tests/store/local_test.py
@@ -15,6 +15,7 @@ def test_kwargs() -> None:
     assert store.kwargs == {
         'stats': False,
     }
+    assert not store.has_stats
 
 
 def test_local_factory() -> None:


### PR DESCRIPTION
# Description
I want to write some code to quickly get the stats related to an arbitrary proxy object. To do this, I ...

- [ ] Added a `has_stats` label onto a store

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing

I added to existing tests

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
